### PR TITLE
Ldes lists from DV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 Add known LDES endpoints to `urls.txt`, one per line.
+
+# Resources
+- Catalog of known streams can be found at: https://www.vlaanderen.be/datavindplaats/catalogus?text.LIKE=ldes&order_relevance=asc
+- For telraam: https://telraam.net/#9/51.0470/3.7206, cannot identify where the LDES is located, and if it is public.
+ 

--- a/urls.txt
+++ b/urls.txt
@@ -1,1 +1,1 @@
-
+https://brugge.ldes.geomobility.eu/observations


### PR DESCRIPTION
The list is provided by Samuel from DV.
Catelog locates at: https://www.vlaanderen.be/datavindplaats/catalogus?text.LIKE=ldes&order_relevance=asc