### PR TITLE
updated conneg supporting URI for VLIZ feeds

### DIFF
--- a/urls.txt
+++ b/urls.txt
@@ -8,8 +8,8 @@ https://apim-iow-apimanagement.azure-api.net/ldes/device-models-by-time,Internet
 https://apim-iow-apimanagement.azure-api.net/ldes/water-quality-observations-by-time,Internet of Water quality observations
 https://apim-iow-apimanagement.azure-api.net/ldes/devices-by-time,Internet of Water devices
 https://graph.irail.be/sncb/connections/feed,Train delays in Belgium
-https://marineregions.org/feed.ttl,The Marine Regions Gazetteer
-https://www.marinespecies.org/rest/feed/taxon,World Registry of Marine Speceies (WoRMS)
+https://marineregions.org/feed,The Marine Regions Gazetteer
+https://aphia.org/feed,World Registry of Marine Speceies (WoRMS)
 https://apidg.gent.be/opendata/adlib2eventstream/v1/adlib/personen,People mentioned in cultural heritage objects in Ghent
 https://apidg.gent.be/opendata/adlib2eventstream/v1/adlib/thesaurus,Thesaurus of the collection of Ghent
 https://apidg.gent.be/opendata/adlib2eventstream/v1/archiefgent/objecten,Objects in the Ghent Archive


### PR DESCRIPTION
Mainly WoRMS got its final destination on the aphia.org domain.
But I assume the conneg-supporting link to the feed for marine-regions also makes more sense?